### PR TITLE
Bugfix - Closes #3

### DIFF
--- a/css/_trumps.scss
+++ b/css/_trumps.scss
@@ -13,3 +13,13 @@ A lot of the declarations in this layer will carry !important (e.g. .text-center
 .u-show {
   display: block;
 }
+
+// Snipcart override for Issue #3
+#snipcart-next {
+  margin-bottom: 40px;
+} 
+@include breakpoint(tablet) {
+  #snipcart-next {
+    margin-bottom: 0px;
+  }  
+}


### PR DESCRIPTION
Quick Explanation:
---
 
This commit adds a new override in `_trumps.scss`, which will add the ability to scroll the next button into view on small screens when adding your address. It is currently blocked from being clicked on as described in https://github.com/DevLifts/devlifts-static/issues/3.

Reference Images:
---
![before](https://user-images.githubusercontent.com/2704192/47231480-fdb93d80-d39a-11e8-952b-5d1e836a35ba.png)
![after](https://user-images.githubusercontent.com/2704192/47231485-014cc480-d39b-11e8-9d6c-274435ed352b.png)



Note: This is my first OSS PR, so if I made any mistakes in the logistics, please let me know so I can improve.