### PR TITLE
Feature - Closes #4

### DIFF
--- a/join/fitStart.html
+++ b/join/fitStart.html
@@ -253,7 +253,19 @@
     </footer>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="https://cdn.snipcart.com/scripts/2.0/snipcart.js" data-api-key="NzM0ZmI5OGMtN2U0Ni00NjRhLWE4NjItZjMzZWZkMTdmY2U5NjM2NTM0Nzg2ODI0ODI2Njkz" id="snipcart"></script>
-
+    <!-- Snipcart card configuration -->
+    <script>
+      if ( Snipcart !== ( undefined || null ) &&
+        Snipcart.api !== ( undefined || null ) &&
+        Snipcart.api.configure !== ( undefined || null ) ) {
+          Snipcart.api.configure('credit_cards', [
+            {'type': 'visa', 'display': 'Visa'},
+            {'type': 'mastercard', 'display': 'Mastercard'},
+            {'type': 'amex', 'display': 'American Express'},
+            {'type': 'discover', 'display': 'Discover'}
+          ]);
+        }
+    </script>
     <script src="../js/app.min.js"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
Quick Explanation:
---

This commit adds a configuration script to the `Snipcart` API that gets loaded in right before it. It should safely parse and execute the code to add in the alternate cards, based on the Snipcart documentation, but I also wrapped it in a sanity check to alleviate any major failures.

From: https://github.com/DevLifts/devlifts-static/issues/4

Reference Images:
---
<img width="375" alt="screen shot 2018-10-19 at 12 42 13 pm" src="https://user-images.githubusercontent.com/2704192/47233338-5fc87180-d3a0-11e8-933c-874961062320.png">
